### PR TITLE
Allow reads for multiple items for tax year 24-25 and below for thread testing

### DIFF
--- a/app/v2/retrieveAccountingType/model/response/RetrieveAccountingTypeResponse.scala
+++ b/app/v2/retrieveAccountingType/model/response/RetrieveAccountingTypeResponse.scala
@@ -16,7 +16,7 @@
 
 package v2.retrieveAccountingType.model.response
 
-import play.api.libs.json.{JsPath, OFormat}
+import play.api.libs.json.{JsPath, OFormat, Reads}
 import v2.common.models.AccountingType
 
 case class RetrieveAccountingTypeResponse(accountingType: AccountingType)
@@ -24,7 +24,9 @@ case class RetrieveAccountingTypeResponse(accountingType: AccountingType)
 object RetrieveAccountingTypeResponse {
 
   implicit val format: OFormat[RetrieveAccountingTypeResponse] = OFormat(
-    (JsPath \\ "accountingType").read[AccountingType].map(RetrieveAccountingTypeResponse.apply),
+    Reads { json =>
+      (json \\ "accountingType").head.validate[AccountingType].map(RetrieveAccountingTypeResponse.apply)
+    },
     (JsPath \ "accountingType").write[AccountingType].contramap[RetrieveAccountingTypeResponse](_.accountingType)
   )
 

--- a/test/v2/retrieveAccountingType/model/response/RetrieveAccountingTypeResponseSpec.scala
+++ b/test/v2/retrieveAccountingType/model/response/RetrieveAccountingTypeResponseSpec.scala
@@ -22,17 +22,19 @@ import v2.common.models.AccountingType
 
 class RetrieveAccountingTypeResponseSpec extends UnitSpec {
 
-  private def validDownstreamJson(typeOfBusiness: String, accountingType: String): JsValue = Json.parse(
-    s"""
-       |{
-       |  "$typeOfBusiness": [
-       |    {
-       |      "accountingType": "$accountingType"
-       |    }
-       |  ]
-       |}
-    """.stripMargin
-  )
+  private def validDownstreamJson(typeOfBusiness: String, accountingType: String, count: Int): JsValue = {
+    val entries: String = Seq.fill(count)(s"""{"accountingType": "$accountingType"}""").mkString(", ")
+
+    Json.parse(
+      s"""
+        |{
+        |  "$typeOfBusiness": [
+        |    $entries
+        |  ]
+        |}
+      """.stripMargin
+    )
+  }
 
   private def validMtdJson(accountingType: String): JsValue = Json.parse(
     s"""
@@ -63,10 +65,14 @@ class RetrieveAccountingTypeResponseSpec extends UnitSpec {
     businessTypes.foreach { typeOfBusiness =>
       accountingTypes.foreach { accountingType =>
         val responseModel: RetrieveAccountingTypeResponse = parsedBody(accountingType)
-        val downstreamJson: JsValue                       = validDownstreamJson(typeOfBusiness, accountingType.toString)
+        def downstreamJson(count: Int): JsValue       = validDownstreamJson(typeOfBusiness, accountingType.toString, count)
 
-        s"correctly parse valid JSON with typeOfBusiness $typeOfBusiness and accountingType $accountingType" in {
-          downstreamJson.as[RetrieveAccountingTypeResponse] shouldBe responseModel
+        s"correctly parse valid JSON with single item for typeOfBusiness $typeOfBusiness and accountingType $accountingType" in {
+          downstreamJson(1).as[RetrieveAccountingTypeResponse] shouldBe responseModel
+        }
+
+        s"correctly parse valid JSON with multiple items for typeOfBusiness $typeOfBusiness and accountingType $accountingType" in {
+          downstreamJson(2).as[RetrieveAccountingTypeResponse] shouldBe responseModel
         }
 
         s"write to flat JSON correctly for typeOfBusiness $typeOfBusiness and accountingType $accountingType" in {


### PR DESCRIPTION
The minimum tax year validation will be removed in the retrieve accounting type soon. We will be allowing retrievals for all tax years possible and a NOT_FOUND will be returned by downstream if no data is present.